### PR TITLE
Minimise flags

### DIFF
--- a/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
@@ -21,7 +21,7 @@ public class AddExerciseCommand extends Command {
             + "Format: add [exercise description], [sets and reps], [workout index]\n"
             + "Parameters:\n"
             + "\tSets and reps: \"5 10\" - 5 sets of 10 reps\n"
-            + "\tWorkout index: Index of workout to add exercise to\n\n"
+            + "\tWorkout index: Index of workout to add exercise to\n"
             + "Example: " + COMMAND_WORD + " Push-ups" + PARAMETER_SEPARATOR + "5 10" + PARAMETER_SEPARATOR + "1";
     public static final String MESSAGE_SUCCESS = "New exercise added: %1$s";
 

--- a/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
@@ -21,7 +21,7 @@ public class AddExerciseCommand extends Command {
             + "Format: add [exercise description], [sets and reps], [workout index]\n"
             + "Parameters:\n"
             + "\tSets and reps: \"5 10\" - 5 sets of 10 reps\n"
-            + "\tWorkout index: Index of workout to add exercise to\n"
+            + "\tWorkout index: Index of workout to add exercise to\n\n"
             + "Example: " + COMMAND_WORD + " Push-ups" + PARAMETER_SEPARATOR + "5 10" + PARAMETER_SEPARATOR + "1";
     public static final String MESSAGE_SUCCESS = "New exercise added: %1$s";
 

--- a/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/AddExerciseCommand.java
@@ -10,10 +10,7 @@ import seedu.duke.ui.Ui;
 import java.util.logging.Logger;
 
 import static seedu.duke.logger.LoggerUtil.setupLogger;
-import static seedu.duke.parser.Parser.EXERCISE_KEYWORD;
-import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
-import static seedu.duke.parser.Parser.SETS_KEYWORD;
-import static seedu.duke.parser.Parser.REPS_KEYWORD;
+import static seedu.duke.parser.Parser.PARAMETER_SEPARATOR;
 
 /**
  * For adding a new exercise to a workout.
@@ -21,10 +18,11 @@ import static seedu.duke.parser.Parser.REPS_KEYWORD;
 public class AddExerciseCommand extends Command {
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an exercise to a workout.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_INDEX " + EXERCISE_KEYWORD + "EXERCISE_NAME "
-            + SETS_KEYWORD + "NUMBER_OF_SETS " + REPS_KEYWORD + "NUMBER_OF_REPS\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "3 " + EXERCISE_KEYWORD + "push ups "
-            + SETS_KEYWORD + "3 " + REPS_KEYWORD + "10";
+            + "Format: add [exercise description], [sets and reps], [workout index]\n"
+            + "Parameters:\n"
+            + "\tSets and reps: \"5 10\" - 5 sets of 10 reps\n"
+            + "\tWorkout index: Index of workout to add exercise to\n"
+            + "Example: " + COMMAND_WORD + " Push-ups" + PARAMETER_SEPARATOR + "5 10" + PARAMETER_SEPARATOR + "1";
     public static final String MESSAGE_SUCCESS = "New exercise added: %1$s";
 
     private static final Logger LOGGER = Logger.getLogger(AddExerciseCommand.class.getName());

--- a/src/main/java/seedu/duke/command/exercise/DisplayExercisesCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/DisplayExercisesCommand.java
@@ -18,8 +18,10 @@ import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
 public class DisplayExercisesCommand extends Command {
     public static final String COMMAND_WORD = "display";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays all exercises in the particular workout.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_INDEX\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "3";
+            + "Format: display [Workout index]\n"
+            + "Parameters:\n"
+            + "Workout index - index of workout to display exercises\n\n"
+            + "\tExample: " + COMMAND_WORD + " 3";
     public static final String MESSAGE_EMPTY_WORKOUT = "You have no exercises.";
 
     private final int workoutIndex;

--- a/src/main/java/seedu/duke/command/exercise/DisplayExercisesCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/DisplayExercisesCommand.java
@@ -20,8 +20,8 @@ public class DisplayExercisesCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays all exercises in the particular workout.\n"
             + "Format: display [Workout index]\n"
             + "Parameters:\n"
-            + "Workout index - index of workout to display exercises\n\n"
-            + "\tExample: " + COMMAND_WORD + " 3";
+            + "\tWorkout index - index of workout to display exercises\n"
+            + "Example: " + COMMAND_WORD + " 3";
     public static final String MESSAGE_EMPTY_WORKOUT = "You have no exercises.";
 
     private final int workoutIndex;

--- a/src/main/java/seedu/duke/command/exercise/MarkExerciseAsDoneCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/MarkExerciseAsDoneCommand.java
@@ -11,8 +11,6 @@ import seedu.duke.ui.Ui;
 import java.util.logging.Logger;
 
 import static seedu.duke.logger.LoggerUtil.setupLogger;
-import static seedu.duke.parser.Parser.EXERCISE_KEYWORD;
-import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
 
 /**
  * Sets isDone attribute in an exercise Object to true.
@@ -23,7 +21,7 @@ public class MarkExerciseAsDoneCommand extends Command {
             + "Format: done [Exercise index], [Workout index]\n"
             + "Parameters:\n"
             + "\tExercise index - Index of exercise to mark done\n"
-            + "\tWorkout index - Index of workout containing exercise to mark done\n\n"
+            + "\tWorkout index - Index of workout containing exercise to mark done\n"
             + "Example: " + COMMAND_WORD + " 1, 2  - Mark exercise 1 from workout 2 as done";
     public static final String MESSAGE_SUCCESS = "Completed: %1$s";
     private static final Logger LOGGER = Logger.getLogger(MarkExerciseAsDoneCommand.class.getName());

--- a/src/main/java/seedu/duke/command/exercise/MarkExerciseAsDoneCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/MarkExerciseAsDoneCommand.java
@@ -20,8 +20,11 @@ import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
 public class MarkExerciseAsDoneCommand extends Command {
     public static final String COMMAND_WORD = "done";
     public static final String MESSAGE_USAGE = "done: Marks the exercise in the workout workout as complete.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_INDEX " + EXERCISE_KEYWORD + "EXERCISE_INDEX\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "3 " + EXERCISE_KEYWORD + "2";
+            + "Format: done [Exercise index], [Workout index]\n"
+            + "Parameters:\n"
+            + "\tExercise index - Index of exercise to mark done\n"
+            + "\tWorkout index - Index of workout containing exercise to mark done\n\n"
+            + "Example: " + COMMAND_WORD + " 1, 2  - Mark exercise 1 from workout 2 as done";
     public static final String MESSAGE_SUCCESS = "Completed: %1$s";
     private static final Logger LOGGER = Logger.getLogger(MarkExerciseAsDoneCommand.class.getName());
 

--- a/src/main/java/seedu/duke/command/exercise/RemoveExerciseCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/RemoveExerciseCommand.java
@@ -19,8 +19,11 @@ import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
 public class RemoveExerciseCommand extends Command {
     public static final String COMMAND_WORD = "remove";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes the exercise from the workout.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_INDEX " + EXERCISE_KEYWORD + "EXERCISE_INDEX\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "1 " + EXERCISE_KEYWORD + "3";
+            + "Format: done [Exercise index], [Workout index]\n"
+            + "Parameters:\n"
+            + "\tExercise index - Index of exercise to mark done\n"
+            + "\tWorkout index - Index of workout containing exercise to mark done\n\n"
+            + "Example: " + COMMAND_WORD + " 1, 2  - remove exercise 1 from workout 2";
     public static final String MESSAGE_SUCCESS = "Removed exercise: %1$s";
     private static final Logger LOGGER = Logger.getLogger(RemoveExerciseCommand.class.getName());
 

--- a/src/main/java/seedu/duke/command/exercise/RemoveExerciseCommand.java
+++ b/src/main/java/seedu/duke/command/exercise/RemoveExerciseCommand.java
@@ -22,7 +22,7 @@ public class RemoveExerciseCommand extends Command {
             + "Format: done [Exercise index], [Workout index]\n"
             + "Parameters:\n"
             + "\tExercise index - Index of exercise to mark done\n"
-            + "\tWorkout index - Index of workout containing exercise to mark done\n\n"
+            + "\tWorkout index - Index of workout containing exercise to mark done\n"
             + "Example: " + COMMAND_WORD + " 1, 2  - remove exercise 1 from workout 2";
     public static final String MESSAGE_SUCCESS = "Removed exercise: %1$s";
     private static final Logger LOGGER = Logger.getLogger(RemoveExerciseCommand.class.getName());

--- a/src/main/java/seedu/duke/command/workout/CreateWorkoutCommand.java
+++ b/src/main/java/seedu/duke/command/workout/CreateWorkoutCommand.java
@@ -16,8 +16,10 @@ import static seedu.duke.parser.Parser.WORKOUT_KEYWORD;
 public class CreateWorkoutCommand extends Command {
     public static final String COMMAND_WORD = "create";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new workout.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_NAME\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "ab workout";
+            + "Format: create [workout description]\n"
+            + "Parameters:\n"
+            + "\tWorkout description - description or name of workout\n\n"
+            + "Example: " + COMMAND_WORD + " abs";
     public static final String MESSAGE_SUCCESS = "New workout created: %1$s";
 
     private final Workout toCreate;

--- a/src/main/java/seedu/duke/command/workout/CreateWorkoutCommand.java
+++ b/src/main/java/seedu/duke/command/workout/CreateWorkoutCommand.java
@@ -18,7 +18,7 @@ public class CreateWorkoutCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new workout.\n"
             + "Format: create [workout description]\n"
             + "Parameters:\n"
-            + "\tWorkout description - description or name of workout\n\n"
+            + "\tWorkout description - description or name of workout\n"
             + "Example: " + COMMAND_WORD + " abs";
     public static final String MESSAGE_SUCCESS = "New workout created: %1$s";
 

--- a/src/main/java/seedu/duke/command/workout/DeleteWorkoutCommand.java
+++ b/src/main/java/seedu/duke/command/workout/DeleteWorkoutCommand.java
@@ -19,8 +19,10 @@ public class DeleteWorkoutCommand extends Command {
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the workout corresponding to the workout index.\n"
-            + "\tParameters: " + WORKOUT_KEYWORD + "WORKOUT_INDEX\n"
-            + "\tExample: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "1";
+            + "Format: delete [Workout index]\n"
+            + "Parameters:\n"
+            + "Workout index - Index of workout to delete\n\n"
+            + "Example: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "1";
     public static final String MESSAGE_SUCCESS = "Deleted workout: %1$s";
     private static final Logger LOGGER = Logger.getLogger(DeleteWorkoutCommand.class.getName());
     private final int workoutIndex;

--- a/src/main/java/seedu/duke/command/workout/DeleteWorkoutCommand.java
+++ b/src/main/java/seedu/duke/command/workout/DeleteWorkoutCommand.java
@@ -21,7 +21,7 @@ public class DeleteWorkoutCommand extends Command {
             + ": Deletes the workout corresponding to the workout index.\n"
             + "Format: delete [Workout index]\n"
             + "Parameters:\n"
-            + "Workout index - Index of workout to delete\n\n"
+            + "\tWorkout index - Index of workout to delete\n"
             + "Example: " + COMMAND_WORD + " " + WORKOUT_KEYWORD + "1";
     public static final String MESSAGE_SUCCESS = "Deleted workout: %1$s";
     private static final Logger LOGGER = Logger.getLogger(DeleteWorkoutCommand.class.getName());

--- a/src/main/java/seedu/duke/parser/AddExerciseParser.java
+++ b/src/main/java/seedu/duke/parser/AddExerciseParser.java
@@ -14,13 +14,45 @@ public class AddExerciseParser extends Parser {
         this.userInputString = userInputString;
     }
 
+    /**
+     * Gets arguments required for an exercise, such as workoutIndex, exerciseName, sets and reps.
+     * commandArgs passed in as [exercise description], [sets and reps], [workout index or name]
+     * @param commandArgs user input without the command word.
+     * @return string array containing workoutIndex, exerciseName, sets and reps.
+     * @throws GetJackDException if any of the above-mentioned arguments are empty.
+     */
+    static String[] getExerciseArgs(String commandArgs) throws GetJackDException {
+        if (!commandArgs.contains(PARAMETER_SEPARATOR)) {
+            throw new GetJackDException("Invalid format for add exercise.");
+        }
+
+        String[] arguments = commandArgs.split(PARAMETER_SEPARATOR);
+        if (arguments.length < 3) {
+            LOGGER.info("Missing exercise arguments");
+            throw new GetJackDException("Error. Missing exercise parameters");
+        }
+
+        String exerciseDescription = arguments[0];
+        String[] setsAndReps = arguments[1].split(" ");
+        String sets = setsAndReps[0];
+        String reps = setsAndReps[1];
+        String workoutIdentifier = arguments[2];
+
+        String[] exerciseArgs = new String[] {exerciseDescription, sets, reps, workoutIdentifier};
+        for (String s : exerciseArgs) {
+            assert (!s.contains(PARAMETER_SEPARATOR));
+        }
+
+        return exerciseArgs;
+    }
+
     private Command prepareAddExercise(String commandArgs) {
         try {
             String[] exerciseArgs = getExerciseArgs(commandArgs);
-            String exerciseName = exerciseArgs[1].trim();
-            int workoutIndex = parseArgsAsIndex(exerciseArgs[0]);
-            int sets = parseArgsAsIndex(exerciseArgs[2]);
-            int reps = parseArgsAsIndex(exerciseArgs[3]);
+            String exerciseName = exerciseArgs[0].trim();
+            int sets = parseArgsAsIndex(exerciseArgs[1]);
+            int reps = parseArgsAsIndex(exerciseArgs[2]);
+            int workoutIndex = parseArgsAsIndex(exerciseArgs[3]);
 
             return new AddExerciseCommand(workoutIndex, exerciseName, sets, reps);
         } catch (GetJackDException e) {

--- a/src/main/java/seedu/duke/parser/CreateWorkoutParser.java
+++ b/src/main/java/seedu/duke/parser/CreateWorkoutParser.java
@@ -14,14 +14,11 @@ public class CreateWorkoutParser extends Parser {
     }
 
     private Command prepareCreateWorkout(String commandArgs) {
-        if (commandArgs.contains(WORKOUT_KEYWORD)) {
-            String workoutName = commandArgs.replace(WORKOUT_KEYWORD, "").trim();
-            if (workoutName.isEmpty()) {
-                return new IncorrectCommand(MESSAGE_INVALID_COMMAND + CreateWorkoutCommand.MESSAGE_USAGE);
-            }
-            return new CreateWorkoutCommand(workoutName);
+        String workoutName = commandArgs.trim();
+        if (workoutName.length() == 0) {
+            return new IncorrectCommand(MESSAGE_INVALID_COMMAND + CreateWorkoutCommand.MESSAGE_USAGE);
         }
-        return new IncorrectCommand(MESSAGE_INVALID_COMMAND + CreateWorkoutCommand.MESSAGE_USAGE);
+        return new CreateWorkoutCommand(workoutName);
     }
 
     @Override

--- a/src/main/java/seedu/duke/parser/DeleteWorkoutParser.java
+++ b/src/main/java/seedu/duke/parser/DeleteWorkoutParser.java
@@ -17,9 +17,7 @@ public class DeleteWorkoutParser extends Parser {
 
     private Command prepareDeleteWorkout(String commandArgs) {
         try {
-            String[] indices = getWorkoutAndExerciseIndices(commandArgs);
-            int workoutIndex = parseArgsAsIndex(indices[0]);
-
+            int workoutIndex = parseWorkoutIndex(commandArgs);
             return new DeleteWorkoutCommand(workoutIndex);
         } catch (GetJackDException e) {
             return new IncorrectCommand(MESSAGE_INVALID_COMMAND + DeleteWorkoutCommand.MESSAGE_USAGE);

--- a/src/main/java/seedu/duke/parser/DisplayExerciseParser.java
+++ b/src/main/java/seedu/duke/parser/DisplayExerciseParser.java
@@ -17,9 +17,7 @@ public class DisplayExerciseParser extends Parser {
 
     private Command prepareDisplayExercises(String commandArgs) {
         try {
-            String[] indices = getWorkoutAndExerciseIndices(commandArgs);
-            int workoutIndex = parseArgsAsIndex(indices[0]);
-
+            int workoutIndex = parseWorkoutIndex(commandArgs);
             return new DisplayExercisesCommand(workoutIndex);
         } catch (GetJackDException e) {
             return new IncorrectCommand(MESSAGE_INVALID_COMMAND + DisplayExercisesCommand.MESSAGE_USAGE);

--- a/src/main/java/seedu/duke/parser/MarkExerciseAsDoneParser.java
+++ b/src/main/java/seedu/duke/parser/MarkExerciseAsDoneParser.java
@@ -16,9 +16,9 @@ public class MarkExerciseAsDoneParser extends Parser {
 
     private Command prepareMarkExerciseAsDone(String commandArgs) {
         try {
-            String[] indices = getWorkoutAndExerciseIndices(commandArgs);
-            int workoutIndex = parseArgsAsIndex(indices[0]);
-            int exerciseIndex = parseArgsAsIndex(indices[1]);
+            int[] indices = parseWorkoutAndExerciseIndex(commandArgs);
+            int exerciseIndex = indices[0];
+            int workoutIndex = indices[1];
 
             return new MarkExerciseAsDoneCommand(workoutIndex, exerciseIndex);
         } catch (GetJackDException e) {

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -18,6 +18,7 @@ public abstract class Parser {
     public static String EXERCISE_KEYWORD = "/e ";
     public static String SETS_KEYWORD = "/s ";
     public static String REPS_KEYWORD = "/r ";
+    public static final String PARAMETER_SEPARATOR = ", ";
     protected String userInputString;
 
     public Parser(String userInputString) {
@@ -44,55 +45,6 @@ public abstract class Parser {
         String[] commandTypeAndParams = splitCommandWordsAndArgs(userInputString, "\\s+");
         String commandArgs = commandTypeAndParams[1].trim();
         return commandArgs;
-    }
-
-    /**
-     * Gets arguments required for an exercise, such as workoutIndex, exerciseName, sets and reps.
-     *
-     * @param commandArgs user input without the command word.
-     * @return string array containing workoutIndex, exerciseName, sets and reps.
-     * @throws GetJackDException if any of the above-mentioned arguments are empty.
-     */
-    static String[] getExerciseArgs(String commandArgs) throws GetJackDException {
-        if (!commandArgs.contains(WORKOUT_KEYWORD) && !commandArgs.contains(EXERCISE_KEYWORD)
-                && !commandArgs.contains(SETS_KEYWORD) && !commandArgs.contains(REPS_KEYWORD)) {
-            throw new GetJackDException("Invalid format for add exercise.");
-        }
-        String args = commandArgs.replace(WORKOUT_KEYWORD, "").trim();
-
-        String[] workoutIndexAndExerciseArgs = splitCommandWordsAndArgs(args, EXERCISE_KEYWORD);
-
-        String[] nameAndSetsReps = splitCommandWordsAndArgs(workoutIndexAndExerciseArgs[1].trim(), SETS_KEYWORD);
-
-        String[] setsAndReps = splitCommandWordsAndArgs(nameAndSetsReps[1].trim(), REPS_KEYWORD);
-
-        String workoutIndex = workoutIndexAndExerciseArgs[0].trim();
-        String exerciseName = nameAndSetsReps[0].trim();
-        String sets = setsAndReps[0].trim();
-        String reps = setsAndReps[1].trim();
-
-        String[] exerciseArgs = new String[]{workoutIndex, exerciseName, sets, reps};
-        for (String s : exerciseArgs) {
-            assert (!s.contains(WORKOUT_KEYWORD));
-            assert (!s.contains(EXERCISE_KEYWORD));
-            assert (!s.contains(SETS_KEYWORD));
-            assert (!s.contains(REPS_KEYWORD));
-        }
-
-        if (workoutIndex.isEmpty()) {
-            LOGGER.info("error getting exercise arguments: empty workout index");
-            throw new GetJackDException("Error. Empty workout index");
-        }
-        if (exerciseName.isEmpty()) {
-            LOGGER.info("error getting exercise arguments: empty exercise name");
-            throw new GetJackDException("Error. Empty exercise name.");
-        }
-        if (sets.isEmpty() || reps.isEmpty()) {
-            LOGGER.info("error getting exercise arguments: empty sets or reps");
-            throw new GetJackDException("Error. Empty sets or reps.");
-        }
-
-        return exerciseArgs;
     }
 
     /**

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -13,11 +13,9 @@ import static seedu.duke.logger.LoggerUtil.setupLogger;
  */
 public abstract class Parser {
     static final Logger LOGGER = Logger.getLogger(Parser.class.getName());
-    static final String MESSAGE_INVALID_COMMAND = "Invalid command format\n";
+    static final String MESSAGE_INVALID_COMMAND = "Invalid command format\n\n";
     public static String WORKOUT_KEYWORD = "/w ";
     public static String EXERCISE_KEYWORD = "/e ";
-    public static String SETS_KEYWORD = "/s ";
-    public static String REPS_KEYWORD = "/r ";
     public static final String PARAMETER_SEPARATOR = ", ";
     protected String userInputString;
 
@@ -45,6 +43,27 @@ public abstract class Parser {
         String[] commandTypeAndParams = splitCommandWordsAndArgs(userInputString, "\\s+");
         String commandArgs = commandTypeAndParams[1].trim();
         return commandArgs;
+    }
+
+
+    static int parseWorkoutIndex(String commandArgs) throws GetJackDException {
+        String arg = commandArgs.trim();
+        int workoutIndex = parseArgsAsIndex(arg);
+        return workoutIndex;
+    }
+
+    /**
+     * For parsing workout and exercise index for "done" and "remove" commands.
+     * @param commandArgs command arguments from user, in the format "workoutIndex, exerciseIndex"
+     * @return int[2] the indices of workout and exercise
+     * @throws GetJackDException when workout or exercise indices are not valid
+     */
+    static int[] parseWorkoutAndExerciseIndex(String commandArgs) throws GetJackDException {
+        String[] args = commandArgs.split(PARAMETER_SEPARATOR);
+        int exerciseIndex = parseArgsAsIndex(args[0]);
+        int workoutIndex = parseArgsAsIndex(args[1]);
+        int[] indices = {workoutIndex, exerciseIndex};
+        return indices;
     }
 
     /**

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -67,40 +67,6 @@ public abstract class Parser {
     }
 
     /**
-     * Gets workout and exercise indices.
-     *
-     * @param commandArgs raw input string without the command word.
-     * @return String array of size 2. If there is no workout index, empty String array is returned.
-     *         If there is a workout index but no exercise index, only workout index is returned.
-     *         Otherwise, both workout index and exercise index are returned.
-     */
-    static String[] getWorkoutAndExerciseIndices(String commandArgs) {
-        if (!commandArgs.contains(WORKOUT_KEYWORD)) {
-            return new String[]{"", ""};
-        }
-
-        if (!commandArgs.contains(EXERCISE_KEYWORD)) {
-            assert (commandArgs.contains(WORKOUT_KEYWORD));
-            String workoutIndex = commandArgs.replace(WORKOUT_KEYWORD, "").trim();
-            return new String[]{workoutIndex, ""};
-        }
-
-        assert (commandArgs.contains(WORKOUT_KEYWORD));
-        assert (commandArgs.contains(EXERCISE_KEYWORD));
-
-        String[] args = splitCommandWordsAndArgs(commandArgs, EXERCISE_KEYWORD);
-        String workoutIndex = args[0].replace(WORKOUT_KEYWORD, "").trim();
-        String exerciseIndex = args[1].trim();
-
-        assert (!workoutIndex.contains(WORKOUT_KEYWORD));
-        assert (!workoutIndex.contains(EXERCISE_KEYWORD));
-        assert (!exerciseIndex.contains(WORKOUT_KEYWORD));
-        assert (!exerciseIndex.contains(EXERCISE_KEYWORD));
-
-        return new String[]{workoutIndex, exerciseIndex};
-    }
-
-    /**
      * Given a string and a keyword, this method splits the string around the keyword into 2.
      *
      * @param input   String

--- a/src/main/java/seedu/duke/parser/RemoveExerciseParser.java
+++ b/src/main/java/seedu/duke/parser/RemoveExerciseParser.java
@@ -16,9 +16,9 @@ public class RemoveExerciseParser extends Parser {
 
     private Command prepareRemoveExercise(String commandArgs) {
         try {
-            String[] indices = getWorkoutAndExerciseIndices(commandArgs);
-            int workoutIndex = parseArgsAsIndex(indices[0]);
-            int exerciseIndex = parseArgsAsIndex(indices[1]);
+            int [] indices = parseWorkoutAndExerciseIndex(commandArgs);
+            int exerciseIndex =indices[0];
+            int workoutIndex = indices[1];
 
             return new RemoveExerciseCommand(workoutIndex, exerciseIndex);
         } catch (GetJackDException e) {

--- a/src/main/java/seedu/duke/parser/RemoveExerciseParser.java
+++ b/src/main/java/seedu/duke/parser/RemoveExerciseParser.java
@@ -17,7 +17,7 @@ public class RemoveExerciseParser extends Parser {
     private Command prepareRemoveExercise(String commandArgs) {
         try {
             int [] indices = parseWorkoutAndExerciseIndex(commandArgs);
-            int exerciseIndex =indices[0];
+            int exerciseIndex = indices[0];
             int workoutIndex = indices[1];
 
             return new RemoveExerciseCommand(workoutIndex, exerciseIndex);

--- a/src/test/java/seedu/duke/parser/CommandManagerTest.java
+++ b/src/test/java/seedu/duke/parser/CommandManagerTest.java
@@ -7,7 +7,9 @@ import seedu.duke.command.IncorrectCommand;
 import seedu.duke.command.exercise.AddExerciseCommand;
 import seedu.duke.command.exercise.MarkExerciseAsDoneCommand;
 import seedu.duke.command.workout.DeleteWorkoutCommand;
+import seedu.duke.exception.GetJackDException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,53 +38,23 @@ class CommandManagerTest {
     }
 
     @Test
-    void generateCommand_deleteWorkoutCommandNoWorkoutIndex_returnsIncorrectCommand() {
-        String[] inputs = {"delete", "delete /w ", "delete "};
-        for (String input : inputs) {
-            Command result = generator.generateCommand(input);
-            assertTrue(result instanceof IncorrectCommand);
-        }
-    }
-
-    @Test
     void generateCommand_deleteWorkoutCommandCorrect_returnsDeleteCommand() {
         int testIndex = 1;
-        String input = "delete /w " + testIndex;
+        String input = "delete " + testIndex;
         DeleteWorkoutCommand result = (DeleteWorkoutCommand) generator.generateCommand(input);
         assertEquals(result.getWorkoutIndex(), testIndex);
     }
 
     @Test
-    void generateCommand_addExerciseCommandNoWorkoutIndex_returnsIncorrectCommand() {
-        String input = "add /w /e Exercise /s 10 /r 100";
-        Command result = generator.generateCommand(input);
-        assertTrue(result instanceof IncorrectCommand);
-    }
-
-    @Test
-    void generateCommand_addExerciseCommandNoSets_returnsIncorrectCommand() {
-        String input = "add /w 1 /e Exercise /s  /r 100";
-        Command result = generator.generateCommand(input);
-        assertTrue(result instanceof IncorrectCommand);
-    }
-
-    @Test
     void generateCommand_addExerciseCorrect_returnsAddExerciseCommand() {
-        String input = "add /w 1 /e Exercise /s 10 /r 100";
+        String input = "add Exercise, 10 100, 1";
         Command result = generator.generateCommand(input);
         assertTrue(result instanceof AddExerciseCommand);
     }
 
     @Test
-    void generateCommand_markExerciseAsDoneNoWorkoutIndex_returnsIncorrectCommand() {
-        String input = "done /w 1 /e ";
-        Command result = generator.generateCommand(input);
-        assertTrue(result instanceof IncorrectCommand);
-    }
-
-    @Test
     void generateCommand_markExerciseAsDoneCorrect_returnsMarkExerciseAsDoneCommand() {
-        String input = "done /w 1 /e 3";
+        String input = "done 3, 1";
         Command result = generator.generateCommand(input);
         assertTrue(result instanceof MarkExerciseAsDoneCommand);
     }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -6,7 +6,7 @@ import seedu.duke.exception.GetJackDException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static seedu.duke.parser.Parser.getExerciseArgs;
+import static seedu.duke.parser.AddExerciseParser.getExerciseArgs;
 import static seedu.duke.parser.Parser.getWorkoutAndExerciseIndices;
 import static seedu.duke.parser.Parser.splitCommandWordsAndArgs;
 import static seedu.duke.parser.Parser.parseArgsAsIndex;

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -59,7 +59,7 @@ class ParserTest {
     void parseWorkoutAndExerciseIndex_validInput_returnWorkoutAndExerciseIndices() {
         String input = " 2, 3";
         try {
-            assertArrayEquals(new int[]{2, 3}, parseWorkoutAndExerciseIndex(input));
+            assertArrayEquals(new int[]{3, 2}, parseWorkoutAndExerciseIndex(input));
         } catch (GetJackDException e) {
             e.printStackTrace();
         }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static seedu.duke.parser.AddExerciseParser.getExerciseArgs;
-import static seedu.duke.parser.Parser.getWorkoutAndExerciseIndices;
+
+import static seedu.duke.parser.Parser.parseWorkoutAndExerciseIndex;
+import static seedu.duke.parser.Parser.parseWorkoutIndex;
 import static seedu.duke.parser.Parser.splitCommandWordsAndArgs;
 import static seedu.duke.parser.Parser.parseArgsAsIndex;
 
@@ -22,37 +24,53 @@ class ParserTest {
     }
 
     @Test
-    void getExerciseArgs_nonEmptyStringMissingSetsKeyword_throwsException() {
-        String input = "\"/w 1 /e exercise /s 10 100";
+    void getExerciseArgs_nonEmptyStringWorkoutIndex_throwsException() {
+        String input = "Test input, 5 20";
         assertThrows(GetJackDException.class, () -> getExerciseArgs(input));
     }
 
     @Test
     void getExerciseArgs_validInput_returnsStringWithExerciseArgs() {
-        String input = "/w 1 /e exercise /s 10 /r 30";
+        String input = "exercise, 5 20, 1";
         try {
-            assertArrayEquals(new String[]{"1", "exercise", "10", "30"}, getExerciseArgs(input));
+            assertArrayEquals(new String[]{"exercise", "5", "20", "1"}, getExerciseArgs(input));
         } catch (GetJackDException e) {
             e.printStackTrace();
         }
     }
 
     @Test
-    void getWorkoutAndExerciseIndices_noWorkoutKeyword_returnEmptyStringArray() {
-        String input = "/e 1";
-        assertArrayEquals(new String[]{"", ""}, getWorkoutAndExerciseIndices(input));
+    void parseWorkoutIndex_validInput_returnsWorkoutIndex() {
+        String input = "  2  ";
+        try {
+            assertEquals(2, parseWorkoutIndex(input));
+        } catch (GetJackDException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    void getWorkoutAndExerciseIndices_haveWorkoutKeywordNoExerciseKeyword_returnWorkoutIndex() {
-        String input = "/w 4";
-        assertArrayEquals(new String[]{"4", ""}, getWorkoutAndExerciseIndices(input));
+    void parseWorkoutIndex_invalidString_throwsException() {
+        String input = "  a  ";
+        assertThrows(GetJackDException.class, () -> parseWorkoutIndex(input));
     }
 
     @Test
-    void getWorkoutAndExerciseIndices_haveWorkoutAndExerciseKeyword_returnWorkoutAndExerciseIndices() {
-        String input = "/w 4 /e 5";
-        assertArrayEquals(new String[]{"4", "5"}, getWorkoutAndExerciseIndices(input));
+    void parseWorkoutAndExerciseIndex_validInput_returnWorkoutAndExerciseIndices() {
+        String input = " 2, 3";
+        try {
+            assertArrayEquals(new int[]{2, 3}, parseWorkoutAndExerciseIndex(input));
+        } catch (GetJackDException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void parseWorkoutAndExerciseIndex_invalidInputs_throwsException() {
+        assertThrows(GetJackDException.class, () -> parseWorkoutAndExerciseIndex(""));
+        assertThrows(GetJackDException.class, () -> parseWorkoutAndExerciseIndex("a"));
+        assertThrows(GetJackDException.class, () -> parseWorkoutAndExerciseIndex("2 2"));
+        assertThrows(GetJackDException.class, () -> parseWorkoutAndExerciseIndex("2,"));
     }
 
     @Test

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -27,14 +27,19 @@ To find out more information about the command, such as input format and paramet
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 create: Creates a new workout.
-	Parameters: /w WORKOUT_NAME
-	Example: create /w ab workout
+Format: create [workout description]
+Parameters:
+	Workout description - description or name of workout
+Example: create abs
 ________________________________________________________
 ________________________________________________________
 	create: Creates a new workout.
-		Parameters: /w WORKOUT_NAME
-		Example: create /w ab workout
+	Format: create [workout description]
+	Parameters:
+		Workout description - description or name of workout
+	Example: create abs
 ________________________________________________________
 ________________________________________________________
 	New workout created: Legs
@@ -45,42 +50,61 @@ Workout list:
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 add: Adds an exercise to a workout.
-	Parameters: /w WORKOUT_INDEX /e EXERCISE_NAME /s NUMBER_OF_SETS /r NUMBER_OF_REPS
-	Example: add /w 3 /e push ups /s 3 /r 10
+Format: add [exercise description], [sets and reps], [workout index]
+Parameters:
+	Sets and reps: "5 10" - 5 sets of 10 reps
+	Workout index: Index of workout to add exercise to
+Example: add Push-ups, 5 10, 1
 ________________________________________________________
 ________________________________________________________
 	add: Adds an exercise to a workout.
-		Parameters: /w WORKOUT_INDEX /e EXERCISE_NAME /s NUMBER_OF_SETS /r NUMBER_OF_REPS
-		Example: add /w 3 /e push ups /s 3 /r 10
+	Format: add [exercise description], [sets and reps], [workout index]
+	Parameters:
+		Sets and reps: "5 10" - 5 sets of 10 reps
+		Workout index: Index of workout to add exercise to
+	Example: add Push-ups, 5 10, 1
 ________________________________________________________
 ________________________________________________________
 	New exercise added: [ ] Squats | 3 sets of 10 reps
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 done: Marks the exercise in the workout workout as complete.
-	Parameters: /w WORKOUT_INDEX /e EXERCISE_INDEX
-	Example: done /w 3 /e 2
+Format: done [Exercise index], [Workout index]
+Parameters:
+	Exercise index - Index of exercise to mark done
+	Workout index - Index of workout containing exercise to mark done
+Example: done 1, 2  - Mark exercise 1 from workout 2 as done
 ________________________________________________________
 ________________________________________________________
 	done: Marks the exercise in the workout workout as complete.
-		Parameters: /w WORKOUT_INDEX /e EXERCISE_INDEX
-		Example: done /w 3 /e 2
+	Format: done [Exercise index], [Workout index]
+	Parameters:
+		Exercise index - Index of exercise to mark done
+		Workout index - Index of workout containing exercise to mark done
+	Example: done 1, 2  - Mark exercise 1 from workout 2 as done
 ________________________________________________________
 ________________________________________________________
 	Completed: [X] Squats | 3 sets of 10 reps
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 display: Displays all exercises in the particular workout.
-	Parameters: /w WORKOUT_INDEX
-	Example: display /w 3
+Format: display [Workout index]
+Parameters:
+	Workout index - index of workout to display exercises
+Example: display 3
 ________________________________________________________
 ________________________________________________________
 	display: Displays all exercises in the particular workout.
-		Parameters: /w WORKOUT_INDEX
-		Example: display /w 3
+	Format: display [Workout index]
+	Parameters:
+		Workout index - index of workout to display exercises
+	Example: display 3
 ________________________________________________________
 ________________________________________________________
 Exercises in mentioned workout:
@@ -88,14 +112,21 @@ Exercises in mentioned workout:
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 remove: Removes the exercise from the workout.
-	Parameters: /w WORKOUT_INDEX /e EXERCISE_INDEX
-	Example: remove /w 1 /e 3
+Format: done [Exercise index], [Workout index]
+Parameters:
+	Exercise index - Index of exercise to mark done
+	Workout index - Index of workout containing exercise to mark done
+Example: remove 1, 2  - remove exercise 1 from workout 2
 ________________________________________________________
 ________________________________________________________
 	remove: Removes the exercise from the workout.
-		Parameters: /w WORKOUT_INDEX /e EXERCISE_INDEX
-		Example: remove /w 1 /e 3
+	Format: done [Exercise index], [Workout index]
+	Parameters:
+		Exercise index - Index of exercise to mark done
+		Workout index - Index of workout containing exercise to mark done
+	Example: remove 1, 2  - remove exercise 1 from workout 2
 ________________________________________________________
 ________________________________________________________
 	Removed exercise: [X] Squats | 3 sets of 10 reps
@@ -105,14 +136,19 @@ ________________________________________________________
 ________________________________________________________
 ________________________________________________________
 Invalid command format
+
 delete: Deletes the workout corresponding to the workout index.
-	Parameters: /w WORKOUT_INDEX
-	Example: delete /w 1
+Format: delete [Workout index]
+Parameters:
+	Workout index - Index of workout to delete
+Example: delete /w 1
 ________________________________________________________
 ________________________________________________________
 	delete: Deletes the workout corresponding to the workout index.
-		Parameters: /w WORKOUT_INDEX
-		Example: delete /w 1
+	Format: delete [Workout index]
+	Parameters:
+		Workout index - Index of workout to delete
+	Example: delete /w 1
 ________________________________________________________
 ________________________________________________________
 	Deleted workout: Legs

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -2,23 +2,23 @@ invalid command
 help
 create
 help create
-create /w Legs
+create Legs
 list
 add
 help add
-add /w 1 /e Squats /s 3 /r 10
+add Squats, 3 10, 1
 done
 help done
-done /w 1 /e 1
+done 1, 1
 display
 help display
-display /w 1
+display 1
 remove
 help remove
-remove /w 1 /e 1
-display /w 1
+remove 1, 1
+display 1
 delete
 help delete
-delete /w 1
+delete 1
 list
 bye


### PR DESCRIPTION
Change Parser and Command classes to minimise the use of flags, so that users will not have to remember the different kinds of flags.

Instead, a comma ", " is used to indicate and separate parameters. The new command formats are: 
- add [exercise description], [sets and reps], [workout index]
- remove [exercise index], [workout index]
- done [exercise index], [workout index]
- create [workout description]
- delete [workout index]
- display [workout index]

Other commands not mentioned are unchanged.
